### PR TITLE
Fix tests memory issues with different include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,31 +28,19 @@ endif()
 
 cm_project(algebra WORKSPACE_NAME ${CMAKE_WORKSPACE_NAME} LANGUAGES ASM C CXX)
 
-if(NOT Boost_FOUND AND NOT CMAKE_CROSSCOMPILING)
-    find_package(Boost)
-endif()
-
 include(CMDeploy)
 
 option(BUILD_BENCH_TESTS "Build performance benchmark tests" FALSE)
 option(BUILD_EXAMPLES "Build examples" FALSE)
 
 # Blurprint components are using point {0, 0} as a point in infinity, while the stadard is {0, 1}
-# for most curves. We will use compatibility mode with blueprint as default. Setting this flag to 
+# for most curves. We will use compatibility mode with blueprint as default. Setting this flag to
 # TRUE will change the value of inf point for all curves to the standard value.
 option(STANDARD_EC_INF_POINTS "Use standard zero points for Eliptic Curves" FALSE)
 
 if(STANDARD_EC_INF_POINTS)
     add_definitions(-DSTANDARD_EC_INF_POINTS_ENABLED)
 endif()
-
-list(APPEND ${CURRENT_PROJECT_NAME}_PUBLIC_HEADERS)
-
-list(APPEND ${CURRENT_PROJECT_NAME}_UNGROUPED_SOURCES)
-
-list(APPEND ${CURRENT_PROJECT_NAME}_HEADERS ${${CURRENT_PROJECT_NAME}_PUBLIC_HEADERS})
-
-list(APPEND ${CURRENT_PROJECT_NAME}_SOURCES ${${CURRENT_PROJECT_NAME}_UNGROUPED_SOURCES})
 
 cm_setup_version(VERSION 0.1.0 PREFIX ${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME})
 
@@ -63,14 +51,11 @@ set_target_properties(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} PROPERTIES
 
 target_include_directories(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} INTERFACE
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                           $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
-
-                           $<$<BOOL:${Boost_FOUND}>:${Boost_INCLUDE_DIRS}>)
+                           $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
 
 target_link_libraries(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} INTERFACE
                       ${CMAKE_WORKSPACE_NAME}::multiprecision
-
-                      ${Boost_LIBRARIES})
+                      Boost::unit_test_framework)
 
 cm_deploy(TARGETS ${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME}
           INCLUDE include

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,17 +6,12 @@
 # http://www.boost.org/LICENSE_1_0.txt
 #---------------------------------------------------------------------------#
 
-include(CMTest)
-
-if(NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
-    find_package(Boost REQUIRED COMPONENTS unit_test_framework)
-endif()
-
-cm_test_link_libraries(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME}
-
-                       ${CMAKE_WORKSPACE_NAME}::multiprecision
-
-                       ${Boost_LIBRARIES})
+cm_test_link_libraries(
+    ${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME}
+    ${CMAKE_WORKSPACE_NAME}::multiprecision
+    Boost::unit_test_framework
+    Boost::random
+)
 
 add_custom_target(algebra_runtime_tests)
 
@@ -24,33 +19,17 @@ macro(define_runtime_algebra_test name)
     set(test_name "algebra_${name}_test")
     add_dependencies(algebra_runtime_tests ${test_name})
 
-    set(additional_args "")
-    if(ENABLE_JUNIT_TEST_OUTPUT)
-        set(TEST_RESULTS_DIR "${CMAKE_CURRENT_BINARY_DIR}/junit_results")
-        set(TEST_LOGS_DIR "${TEST_RESULTS_DIR}/logs")
-        file(MAKE_DIRECTORY ${TEST_LOGS_DIR})
-
-        set(additional_args "--log_format=JUNIT"
-                            "--log_sink=${TEST_LOGS_DIR}/${test_name}.xml")
-    endif()
-
-    cm_test(NAME ${test_name} SOURCES ${name}.cpp ARGS ${additional_args})
+    cm_test(NAME ${test_name} SOURCES ${name}.cpp)
 
     target_include_directories(${test_name} PRIVATE
-                               "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-                               "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>"
 
-                               ${Boost_INCLUDE_DIRS})
+        ${Boost_INCLUDE_DIRS}
+    )
 
     set_target_properties(${test_name} PROPERTIES CXX_STANDARD 17
         CXX_STANDARD_REQUIRED TRUE)
-
-    get_target_property(target_type Boost::unit_test_framework TYPE)
-    if(target_type STREQUAL "SHARED_LIB")
-        target_compile_definitions(${test_name} PRIVATE BOOST_TEST_DYN_LINK)
-    elseif(target_type STREQUAL "STATIC_LIB")
-
-    endif()
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         target_compile_options(${test_name} PRIVATE "-fconstexpr-steps=2147483647" "-ftemplate-backtrace-limit=0")
@@ -71,13 +50,6 @@ macro(define_compile_time_algebra_test name)
                                ${Boost_INCLUDE_DIRS})
 
     set_target_properties(algebra_${name}_compile_test PROPERTIES CXX_STANDARD 17)
-
-    get_target_property(target_type Boost::unit_test_framework TYPE)
-    if(target_type STREQUAL "SHARED_LIB")
-        target_compile_definitions(algebra_${name}_compile_test PRIVATE BOOST_TEST_DYN_LINK)
-    elseif(target_type STREQUAL "STATIC_LIB")
-
-    endif()
 endmacro()
 
 set(RUNTIME_TESTS_NAMES
@@ -105,4 +77,3 @@ endforeach()
 if(BUILD_BENCH_TESTS)
     cm_add_test_subdirectory(bench_test)
 endif()
-

--- a/test/bench_test/bench_curves.cpp
+++ b/test/bench_test/bench_curves.cpp
@@ -30,7 +30,7 @@
 #include <chrono>
 #include <type_traits>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 

--- a/test/bench_test/bench_fields.cpp
+++ b/test/bench_test/bench_fields.cpp
@@ -30,7 +30,7 @@
 #include <cstdint>
 #include <string>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 

--- a/test/curves.cpp
+++ b/test/curves.cpp
@@ -30,7 +30,7 @@
 #include <chrono>
 #include <type_traits>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 
@@ -72,10 +72,9 @@ namespace boost {
     }        // namespace test_tools
 }    // namespace boost
 
-// if target == check-algebra just data/curves.json
-std::string test_data = std::string(TEST_DATA_DIR) + R"(curves.json)";
-
 boost::property_tree::ptree string_data(std::string test_name) {
+    // if target == check-algebra just data/curves.json
+    static std::string test_data = std::string(TEST_DATA_DIR) + R"(curves.json)";
     boost::property_tree::ptree string_data;
     boost::property_tree::read_json(test_data, string_data);
 

--- a/test/fields.cpp
+++ b/test/fields.cpp
@@ -31,7 +31,7 @@
 #include <cstdint>
 #include <string>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 
@@ -99,10 +99,10 @@ enum field_operation_test_elements : std::size_t {
     elements_set_size
 };
 
-// if target == check-algebra just data/fields.json
-std::string test_data = std::string(TEST_DATA_DIR) + R"(fields.json)";
 
 boost::property_tree::ptree string_data(std::string test_name) {
+    // if target == check-algebra just data/fields.json
+    static std::string test_data = std::string(TEST_DATA_DIR) + R"(fields.json)";
     boost::property_tree::ptree string_data;
     boost::property_tree::read_json(test_data, string_data);
 

--- a/test/fields_static.cpp
+++ b/test/fields_static.cpp
@@ -30,7 +30,7 @@
 #include <cstdint>
 #include <string>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 
@@ -103,7 +103,7 @@ constexpr bool check_field_operations_static(const ElementsRange &elements, cons
     static_assert(elements[e1] * elements[e2] == elements[e1_mul_e2], "mul error");
     static_assert(elements[e1].doubled() == elements[e1_dbl], "dbl error");
     static_assert(elements[e2].inversed() == elements[e2_inv], "inv error");
-    
+
     static_assert(elements[e1].pow(constants[C1]) == elements[e1_pow_C1], "pow error");
     static_assert(elements[e2].squared() == elements[e2_pow_2], "sqr error");
     static_assert((elements[e2].squared()).sqrt() == elements[e2_pow_2_sqrt], "sqrt error");

--- a/test/multiexp.cpp
+++ b/test/multiexp.cpp
@@ -25,7 +25,7 @@
 
 #define BOOST_TEST_MODULE multiexpr_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 

--- a/test/pairing.cpp
+++ b/test/pairing.cpp
@@ -30,7 +30,7 @@
 #include <vector>
 #include <array>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 
@@ -70,9 +70,8 @@ namespace boost {
     }        // namespace test_tools
 }    // namespace boost
 
-std::string test_data = std::string(TEST_DATA_DIR) + R"(pairing.json)";
-
 boost::property_tree::ptree string_data(const std::string &test_name) {
+    static std::string test_data = std::string(TEST_DATA_DIR) + R"(pairing.json)";
     boost::property_tree::ptree string_data;
     boost::property_tree::read_json(test_data, string_data);
 
@@ -112,10 +111,10 @@ void check_pairing_operations(std::vector<Fr_value_type> &Fr_elements,
     BOOST_CHECK_EQUAL((Fr_elements[A2_poly] * Fr_elements[B2_poly] - Fr_elements[VKx_poly] * Fr_elements[VKy_poly]) *
                           Fr_elements[VKz_poly].inversed(),
                       Fr_elements[C2_poly]);
-    
+
     BOOST_CHECK_EQUAL(Fr_elements[A1_poly] * G1_value_type::zero(), G1_value_type::zero());
     BOOST_CHECK_EQUAL(Fr_elements[B1_poly] * G2_value_type::zero(), G2_value_type::zero());
-    
+
     BOOST_CHECK_EQUAL(Fr_elements[VKx_poly] * G1_value_type::one(), G1_elements[VKx]);
     BOOST_CHECK_EQUAL(Fr_elements[VKy_poly] * G2_value_type::one(), G2_elements[VKy]);
     BOOST_CHECK_EQUAL(Fr_elements[VKz_poly] * G2_value_type::one(), G2_elements[VKz]);

--- a/test/short_weierstrass_coordinates.cpp
+++ b/test/short_weierstrass_coordinates.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <type_traits>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 
@@ -58,9 +58,8 @@ namespace boost {
     }        // namespace test_tools
 }    // namespace boost
 
-std::string test_data = std::string(TEST_DATA_DIR) + R"(coordinates.json)";
-
 boost::property_tree::ptree string_data(std::string test_name) {
+    static std::string test_data = std::string(TEST_DATA_DIR) + R"(coordinates.json)";
     boost::property_tree::ptree string_data;
     boost::property_tree::read_json(test_data, string_data);
 


### PR DESCRIPTION
Currently, if we choose g++ Relase build within Nix environment, tests using `<boost/test/included/unit_test.hpp>` and `BOOST_DATA_TEST_CASE` are failing due to heap memory issues (valgrind report is attached below). Technically, tests themselves pass, but process still fails on exit.


Made some expriments. Turned out the issue is gone either if we use `<boost/test/unit_test.hpp>` instead (header for linked Boost setting) or disable linking flags. In other words, `<boost/test/included/unit_test.hpp>` and linking to `Boost::unit_test_framework` are incompatible in this case.


Since in _crypto3_ we have more `<boost/test/unit_test.hpp>` usage, I changed tests to use this header.


<details>
  <summary>Valgring Report</summary>

   ```
make algebra_curves_test && valgrind --leak-check=full --track-origins=yes ./algebra_curves_test 
Building CXX object libs/algebra/test/CMakeFiles/algebra_curves_test.dir/curves.cpp.o
Linking CXX executable algebra_curves_test
Built target algebra_curves_test
==988042== Memcheck, a memory error detector
==988042== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==988042== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==988042== Command: ./algebra_curves_test
==988042== 
Running 296 test cases...

*** No errors detected
==988042== Invalid free() / delete / delete[] / realloc()
==988042==    at 0x48448AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==988042==    by 0x4CF0A32: __cxa_finalize (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/libc.so.6)
==988042==    by 0x4878AF6: ??? (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x40010E1: _dl_call_fini (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x4004E05: _dl_fini (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x4CF0FA4: __run_exit_handlers (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/libc.so.6)
==988042==    by 0x4CF10DD: exit (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/libc.so.6)
==988042==    by 0x4CD8FD4: (below main) (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/libc.so.6)
==988042==  Address 0x4ebc3c0 is 0 bytes inside a block of size 18 free'd
==988042==    at 0x48448AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==988042==    by 0x4CF0FA4: __run_exit_handlers (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/libc.so.6)
==988042==    by 0x4CF10DD: exit (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/libc.so.6)
==988042==    by 0x4CD8FD4: (below main) (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/libc.so.6)
==988042==  Block was alloc'd at
==988042==    at 0x4842013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==988042==    by 0x4C6D59: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) [clone .isra.0] (basic_string.tcc:225)
==988042==    by 0x4C34F9: __static_initialization_and_destruction_0(int, int) [clone .constprop.0] (unit_test_parameters.ipp:97)
==988042==    by 0x4CD90FD: __libc_start_main@@GLIBC_2.34 (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/libc.so.6)
==988042==    by 0x4C5444: (below main) (in /home/user/crypto3/build/libs/algebra/test/algebra_curves_test)
==988042== 
==988042== 
==988042== HEAP SUMMARY:
==988042==     in use at exit: 102 bytes in 5 blocks
==988042==   total heap usage: 3,056,311 allocs, 3,056,311 frees, 234,329,363 bytes allocated
==988042== 
==988042== 18 bytes in 1 blocks are definitely lost in loss record 1 of 5
==988042==    at 0x4842013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==988042==    by 0x487ABE1: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x487A75D: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E92D7: __static_initialization_and_destruction_0(int, int) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E9785: _GLOBAL__sub_I_unit_test_parameters.cpp (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x4004FBD: call_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x40050AB: _dl_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x401B07F: ??? (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042== 
==988042== 20 bytes in 1 blocks are definitely lost in loss record 2 of 5
==988042==    at 0x4842013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==988042==    by 0x487ABE1: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x487A75D: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E8B60: __static_initialization_and_destruction_0(int, int) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E9785: _GLOBAL__sub_I_unit_test_parameters.cpp (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x4004FBD: call_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x40050AB: _dl_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x401B07F: ??? (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042== 
==988042== 20 bytes in 1 blocks are definitely lost in loss record 3 of 5
==988042==    at 0x4842013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==988042==    by 0x487ABE1: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x487A75D: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E8C71: __static_initialization_and_destruction_0(int, int) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E9785: _GLOBAL__sub_I_unit_test_parameters.cpp (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x4004FBD: call_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x40050AB: _dl_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x401B07F: ??? (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042== 
==988042== 21 bytes in 1 blocks are definitely lost in loss record 4 of 5
==988042==    at 0x4842013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==988042==    by 0x487ABE1: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x487A75D: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E8C16: __static_initialization_and_destruction_0(int, int) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E9785: _GLOBAL__sub_I_unit_test_parameters.cpp (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x4004FBD: call_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x40050AB: _dl_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x401B07F: ??? (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042== 
==988042== 23 bytes in 1 blocks are definitely lost in loss record 5 of 5
==988042==    at 0x4842013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==988042==    by 0x487ABE1: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x487A75D: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E905A: __static_initialization_and_destruction_0(int, int) (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x48E9785: _GLOBAL__sub_I_unit_test_parameters.cpp (in /nix/store/0m2ddvr1l4az5l3h0b50l1pll91yqyv8-boost-1.83.0/lib/libboost_unit_test_framework-mt-d-x64.so.1.83.0)
==988042==    by 0x4004FBD: call_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x40050AB: _dl_init (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042==    by 0x401B07F: ??? (in /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2)
==988042== 
==988042== LEAK SUMMARY:
==988042==    definitely lost: 102 bytes in 5 blocks
==988042==    indirectly lost: 0 bytes in 0 blocks
==988042==      possibly lost: 0 bytes in 0 blocks
==988042==    still reachable: 0 bytes in 0 blocks
==988042==         suppressed: 0 bytes in 0 blocks
==988042== 
==988042== For lists of detected and suppressed errors, rerun with: -s
==988042== ERROR SUMMARY: 10 errors from 6 contexts (suppressed: 0 from 0)
   ```
</details>